### PR TITLE
1.8.4

### DIFF
--- a/examples/clubs.js
+++ b/examples/clubs.js
@@ -23,6 +23,12 @@ function run(){
         clubs.club(54).then(club=>{
             console.log('zrt',club)
         })
+        clubs.clubActivities(54, "room").then(club=>{
+            console.log('zrt rooms',club)
+        })
+        clubs.clubMembers(54).then(club=>{
+            console.log('zrt members',club)
+        })
     } catch (e){
         console.error(e)
         process.exit(1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trackmania.io",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trackmania.io",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "license": "GPL-3.0",
       "dependencies": {
         "events": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trackmania.io",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Node.js inplementation of Trackmania Live services (trackmania.io)",
   "main": "src/index.js",
   "scripts": {

--- a/src/Clubs/Clubs.js
+++ b/src/Clubs/Clubs.js
@@ -93,15 +93,52 @@ class Clubs extends EventEmitter {
     async club(clubId, format = true){
         var club = await f.getData.page(url.tabs.club, clubId)
 
-        var members = await f.getData.page(url.tabs.club, clubId + '/members/0')
-
-        club.members = members
-
         if (!format) return club
         else {
             club.name = f.stripFormatting(club.name)
             club.description = f.stripFormatting(club.description)
             return club
+        }
+    }
+
+    /**
+     * Gets the club members. Members are sorted by role and club interaction time.
+     * @param {number} clubId The Club ID
+     * @param {number} page The page number. Defaults to 0 
+     * @returns {object} The list of maps of this campaign
+     */
+     async clubMembers(clubId, page = 0){
+        var members = await f.getData.page(url.tabs.club, clubId + '/members/'+page)
+        return members
+    }
+
+    /**
+     * Gets the club activities.
+     * @param {number} clubId The Club ID
+     * @param {string} filter The type of activities to show. ("all", "campaign", "room", "ranking-club", "news", "skin-upload") Defaults to "all"
+     * @param {number} page The page number. Defaults to 0 
+     * @param {boolean} format Defaults to true, removes chat formatting codes
+     * @returns {object} The list of maps of this campaign
+     */
+     async clubActivities(clubId, filter = "all", page = 0, format = true){
+        var activities = await f.getData.page(url.tabs.club, clubId + '/activities/'+page)
+
+        if (filter == "all"){
+            if (!format) return activities.activities
+            else {
+                activities.activities.forEach(a=>{
+                    a.name = f.stripFormatting(a.name)
+                })
+                return activities.activities
+            }
+        } else {
+            if (!format) return activities.activities.filter(a=>a.type == filter)
+            else {
+                activities.activities.forEach(a=>{
+                    a.name = f.stripFormatting(a.name)
+                })
+                return activities.activities.filter(a=>a.type == filter)
+            }
         }
     }
     

--- a/test/clubs.test.js
+++ b/test/clubs.test.js
@@ -26,4 +26,16 @@ describe('Clubs', function() {
         assert.strictEqual(club.name, "ZeratoR", "This club is not ZeratoR, it's " + club.name)
         assert.strictEqual(club.tag, "ZT.", "This club tag is not ZT., it's " + club.tag)
     });
+
+    it('Club Members', async function() {
+        var club = await clubs.clubMembers(54)
+        assert.strictEqual(typeof club, 'object', 'It returns an ' + typeof club + ' insead of an object')
+        assert.strictEqual(club.members.length, 50)
+        assert.strictEqual(club.members[0].role, 'Creator')
+    });
+
+    it('Club Activities', async function() {
+        var club = await clubs.clubActivities(54)
+        assert.strictEqual(typeof club, 'object', 'It returns an ' + typeof club + ' insead of an object')
+    });
 });

--- a/test/players.test.js
+++ b/test/players.test.js
@@ -61,7 +61,7 @@ describe('Players', function() {
         it('Test 1 - Nadeo', async function() {
             var player = await players.getGroupPlayers("Nadeo")
             assert.strictEqual(typeof player, 'object', 'It returns an ' + typeof player + ' insead of an object')
-            assert.strictEqual(player.length, 22, "The result length is invalid")
+            assert.strictEqual(player.length, 17, "The result length is invalid")
         });
 
         it('Test 2 - Openplanet Team', async function() {


### PR DESCRIPTION
- Add club activities and separate club info and club members (#28)

Please use Club.clubMembers() for fetching clubs because club().then(c=>c.members) is deprecated