### PR TITLE
3.0.5

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -21,3 +21,6 @@
     - name: Current official campaign
       id: currentCampaign
       path: ../../examples/officialCampaign.md
+    - name: Gratefully catch errors
+      id: errorCatches
+      path: ../../examples/errorCatches.md

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -21,6 +21,6 @@
     - name: Current official campaign
       id: currentCampaign
       path: ../../examples/officialCampaign.md
-    - name: Gratefully catch errors
+    - name: Gracefully catch errors
       id: errorCatches
       path: ../../examples/errorCatches.md

--- a/examples/errorCatches.md
+++ b/examples/errorCatches.md
@@ -6,7 +6,7 @@ Most errors can come from an API block.
 
 Every requests is managed with a Promise, so you need to handle that with async/await or with a `.then()` block
 
-### Example with campaign fetch
+### Example with main request
 
 ```js
 const TMIO = require('trackmania.io'),
@@ -38,4 +38,33 @@ client.campaigns.currentSeason().then(async campaign=>{
 
     console.error(err);
 })
+```
+
+### Example with side requests
+
+Side requests is requests made to another domain than trackmania.io (trackmania.exchange for example), this does not throws a error but emit an "error" Event.
+
+Error events is not a big deal than main errors
+
+To catch them, you just need to add a `client.on("error", error=>...)` block
+
+```js
+const TMIO = require('trackmania.io'),
+    client = new TMIO.Client();
+
+client.maps.get("89OtLgP9IRQzmC9n_h0SrIr8l_4").then(map=>{
+    console.log(map.name);
+}).catch(err=>{
+    // Here, we got a tm.io error, because it's the main thing after all
+    
+    console.error(err);
+});
+
+client.on("error", error=>{
+    // But here, errors can come from another services for the map info
+    // Trackmania Exchange for example
+
+    console.error(error);
+});
+
 ```

--- a/examples/errorCatches.md
+++ b/examples/errorCatches.md
@@ -1,0 +1,41 @@
+## Gracefully catches errors
+
+Every error is sent trough a `throw`, meaning that errors is handeled with a `.catch()` block or in a try/catch way.
+
+Most errors can come from an API block.
+
+Every requests is managed with a Promise, so you need to handle that with async/await or with a `.then()` block
+
+### Example with campaign fetch
+
+```js
+const TMIO = require('trackmania.io'),
+    client = new TMIO.Client();
+
+client.campaigns.currentSeason().then(async campaign=>{
+    console.log('The actual official campaign is', campaign.name);
+    console.log('The image URL of this campaign is:', campaign.image);
+
+    try {
+        // Here, we try to execute another request, but in a async way
+        // so we need to use try/catch
+
+        console.log('Top 10 of this campaign:');
+        const leaderboard = await campaign.leaderboard();
+        leaderboard.forEach(top=>{
+            console.log(top.position, top.playerName, "with", top.points, "points");
+        });
+    } catch (err) {
+        // Here, an script or API error is throwed
+        console.error(err);
+
+        // Mostly, if it's an API block, you'll have this message:
+        // "You are blocked from the API. Please get in touch with @Miss#8888 on Discord: https://openplanet.nl/link/discord - or DM me on Twitter: https://twitter.com/codecatt -- For more information on third-party API usage, see the following page: https://openplanet.nl/tmio/api"
+    }
+}).catch(err=>{
+    // An error, sadge
+    // Meanwhile, this is the same as a try/catch
+
+    console.error(err);
+})
+```

--- a/examples/officialCampaign.md
+++ b/examples/officialCampaign.md
@@ -4,14 +4,14 @@
 const TMIO = require('trackmania.io'),
     client = new TMIO.Client();
 
-client.campaigns.currentSeason().then(campaign=>{
+client.campaigns.currentSeason().then(async campaign=>{
     console.log('The actual official campaign is', campaign.name);
     console.log('The image URL of this campaign is:', campaign.image);
 
     console.log('Top 10 of this campaign:');
     const leaderboard = await campaign.leaderboard();
     leaderboard.forEach(top=>{
-        console.log(top.position, top.playerName, "with", top.points, "points")
+        console.log(top.position, top.playerName, "with", top.points, "points");
     });
 });
 

--- a/examples/playerCOTD.md
+++ b/examples/playerCOTD.md
@@ -11,7 +11,7 @@ client.players.get("26d9a7de-4067-4926-9d93-2fe62cd869fc").then(async player=>{
         ${player.name}'s COTD stats:
         ${cotd.count} Cup Of The Day played,
         ${cotd.stats.totalDivWins} wins in any division,
-        ${cotd.stats.averageDivRank * 100}% average rank,
+        ${(cotd.stats.averageDivRank * 100).toFixed(2)}% average rank,
         The best division in overall was Div ${cotd.stats.bestOverall.division},
         The best division in primary COTD was Div ${cotd.stats.bestPrimary.division},
     `);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trackmania.io",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trackmania.io",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "GPL-3.0",
       "dependencies": {
         "events": "3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "events": "3.3.0",
-        "luxon": "^2.2.0",
+        "luxon": "^2.3.0",
         "node-fetch": "2.6.1"
       },
       "devDependencies": {
@@ -2318,9 +2318,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.2.0.tgz",
-      "integrity": "sha512-LwmknessH4jVIseCsizUgveIHwlLv/RQZWC2uDSMfGJs7w8faPUi2JFxfyfMcTPrpNbChTem3Uz6IKRtn+LcIA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.0.tgz",
+      "integrity": "sha512-gv6jZCV+gGIrVKhO90yrsn8qXPKD8HYZJtrUDSfEbow8Tkw84T9OnCyJhWvnJIaIF/tBuiAjZuQHUt1LddX2mg==",
       "engines": {
         "node": ">=12"
       }
@@ -5669,9 +5669,9 @@
       }
     },
     "luxon": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.2.0.tgz",
-      "integrity": "sha512-LwmknessH4jVIseCsizUgveIHwlLv/RQZWC2uDSMfGJs7w8faPUi2JFxfyfMcTPrpNbChTem3Uz6IKRtn+LcIA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.0.tgz",
+      "integrity": "sha512-gv6jZCV+gGIrVKhO90yrsn8qXPKD8HYZJtrUDSfEbow8Tkw84T9OnCyJhWvnJIaIF/tBuiAjZuQHUt1LddX2mg=="
     },
     "markdown-it": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trackmania.io",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Node.js inplementation of Trackmania Live services (trackmania.io)",
   "main": "src/index.js",
   "types": "typings/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://tmio.greep.gq/",
   "dependencies": {
     "events": "3.3.0",
-    "luxon": "^2.2.0",
+    "luxon": "^2.3.0",
     "node-fetch": "2.6.1"
   },
   "devDependencies": {

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -151,5 +151,5 @@ module.exports = Client;
 /**
  * Emitted when there is an error when fetching external data (Trackmania.exchange for example).
  * @event Client#error
- * @param {Error} error The error
+ * @param {string} error The error
  */

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -109,7 +109,8 @@ class APIRequest {
                 } else {
                     if (response.status >= 500) {
                         const json = await response.json();
-                        throw json.error;
+                        if (json.error) throw json.error;
+                        else throw json;
                     } else throw response.statusText;
                 }
             })

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -94,18 +94,20 @@ class APIRequest {
                  * @param {Response} response The response received from the API
                  */
                 this.client.emit('apiResponse', this, response);
-                // Save the rate limit details
-                if (this.url.startsWith(new ReqUtil(this.client).tmioAPIURL)){
-                    this.client.ratelimit = {
-                        ratelimit: Number(response.headers.raw()['x-ratelimit-limit'][0]),
-                        remaining: Number(response.headers.raw()['x-ratelimit-remaining'][0]),
-                        reset: new Date(Number(response.headers.raw()['x-ratelimit-reset'][0]) * 1000)
-                    };
-                }
+
                 if (response.status >= 200 && response.status < 300) {
+                    // Save the rate limit details
+                    if (this.url.startsWith(new ReqUtil(this.client).tmioAPIURL)){
+                        this.client.ratelimit = {
+                            ratelimit: Number(response.headers.raw()['x-ratelimit-limit'][0]),
+                            remaining: Number(response.headers.raw()['x-ratelimit-remaining'][0]),
+                            reset: new Date(Number(response.headers.raw()['x-ratelimit-reset'][0]) * 1000)
+                        };
+                    }
+                    
                     return await response.json();
                 } else {
-                    if (response.status == 500) {
+                    if (response.status >= 500) {
                         const json = await response.json();
                         throw json.error;
                     } else throw response.statusText;

--- a/src/structures/Campaign.js
+++ b/src/structures/Campaign.js
@@ -92,6 +92,23 @@ class Campaign {
     }
 
     /**
+     * Get the number of maps in the campaign.
+     * @type {number}
+     */
+    get mapCount() {
+        return this._data.playlist.length;
+    }
+
+    /**
+     * Get a specific map of the campaign.
+     * @param {number} index The index of the map.
+     * @returns {Promise<TMMap>}
+     */
+    async map(index) {
+        return await this.client.maps.get(this._data.playlist[index].mapUid);
+    }
+
+    /**
      * The list of maps in the campaign.
      * @returns {Promise<Array<TMMap>>}
      * @example

--- a/src/structures/TMMap.js
+++ b/src/structures/TMMap.js
@@ -66,7 +66,7 @@ class TMMap {
      * @type {string}
      */
     get storageId() {
-        return this.thumbnail.replace(/^[a-z:/.]*([^]*)\.[a-z]*$/gi, '$1');
+        return this.thumbnail.replace(/^[a-z:/.]*\/([^]*)\.[a-z]*$$/gi, '$1');
     }
 
     /**

--- a/src/util/defaultOptions.js
+++ b/src/util/defaultOptions.js
@@ -49,12 +49,17 @@ class defaultOptionsAPI {
          */
         this.paths = new defaultOptionsAPIPaths();
 
-        /**
-         * The default User Agent to use.
-         * @type {?string}
-         */
-        this.useragent = null;
-
+        if (!this.key && 'TMIO_UA' in process.env) {
+            /**
+             * The default User Agent to use.
+             * If present, this defaults to `process.env.TMIO_UA` when instantiating the client
+             * @type {?string}
+             */
+            this.useragent = process.env.TMIO_UA;
+        } else {
+            this.useragent = null;
+        }
+            
         if (!this.key && 'TMIO_API' in process.env) {
             /**
              * The API Key to use. It must contains "yourname:theactualsecretkey".

--- a/src/util/defaultOptions.js
+++ b/src/util/defaultOptions.js
@@ -49,7 +49,7 @@ class defaultOptionsAPI {
          */
         this.paths = new defaultOptionsAPIPaths();
 
-        if (!this.key && 'TMIO_UA' in process.env) {
+        if (!this.useragent && 'TMIO_UA' in process.env) {
             /**
              * The default User Agent to use.
              * If present, this defaults to `process.env.TMIO_UA` when instantiating the client

--- a/typings/structures/Campaign.d.ts
+++ b/typings/structures/Campaign.d.ts
@@ -56,6 +56,17 @@ declare class Campaign {
      */
     get leaderboardId(): string;
     /**
+     * Get the number of maps in the campaign.
+     * @type {number}
+     */
+    get mapCount(): number;
+    /**
+     * Get a specific map of the campaign.
+     * @param {number} index The index of the map.
+     * @returns {Promise<TMMap>}
+     */
+    map(index: number): Promise<TMMap>;
+    /**
      * The list of maps in the campaign.
      * @returns {Promise<Array<TMMap>>}
      * @example

--- a/typings/util/defaultOptions.d.ts
+++ b/typings/util/defaultOptions.d.ts
@@ -45,6 +45,7 @@ declare class defaultOptionsAPI {
     paths: defaultOptionsAPIPaths;
     /**
      * The default User Agent to use.
+     * If present, this defaults to `process.env.TMIO_UA` when instantiating the client
      * @type {?string}
      */
     useragent: string | null;


### PR DESCRIPTION
- Fixing wrong regex for `TMMap.storageId`
- Useragent uses TMIO_UA as env variable by default
- Fixing mistakes on examples & create error catch example
- Fix ratelimit details not saved correctly in a case of server error (#77)
- Add `Campaign.mapCount` and `Campaign.map(index)` (#78)