### PR TITLE
Remove fetch map leaderboard from Manager and add on TMMap

### DIFF
--- a/src/managers/MapManager.js
+++ b/src/managers/MapManager.js
@@ -52,15 +52,6 @@ class MapManager{
         const map = this.client.options.api.paths.tmio.tabs.map;
         const res = await this.client._apiReq(`${new ReqUtil(this.client).tmioAPIURL}/${map}/${mapUid}`);
 
-        // Get map leaderboard
-        try {
-            const leaderboard = this.client.options.api.paths.tmio.tabs.leaderboard,
-                leaderboardRes = await this.client._apiReq(`${new ReqUtil(this.client).tmioAPIURL}/${leaderboard}/${map}/${mapUid}?offset=0&length=100`);
-            res["leaderboard"] = leaderboardRes;
-        } catch (e) {
-            this.client.emit('error', e);
-        }
-
         const theMap = new TMMap(this.client, res);
         if (cache) {
             res._cachedTimestamp = Date.now();

--- a/typings/structures/TMMap.d.ts
+++ b/typings/structures/TMMap.d.ts
@@ -21,6 +21,11 @@ declare class TMMap {
      */
     medalTimes: TMMapMedalTimes;
     /**
+     * The map cached leaderboard data. You should use the leaderboardLoadMore() the first time to load the leaderboard.
+     * @type {Array<TMMapLeaderboard>}
+     */
+    leaderboard: Array<TMMapLeaderboard>;
+    /**
      * The map name.
      * @type {string}
      */
@@ -106,15 +111,11 @@ declare class TMMap {
      */
     exchange(): Promise<TMExchangeMap | null>;
     /**
-     * The map leaderboard.
-     * @type {?Array<TMMapLeaderboard>}
-     */
-    get leaderboard(): TMMapLeaderboard[];
-    /**
-     * Load 100 more results in the leaderboard.
+     * Load more results in the leaderboard.
+     * @param {number} [nbOfResults=100] The number of results to load. (max 100)
      * @returns {Promise<?Array<TMMapLeaderboard>>}
      */
-    leaderboardLoadMore(): Promise<Array<TMMapLeaderboard> | null>;
+    leaderboardLoadMore(nbOfResults?: number): Promise<Array<TMMapLeaderboard> | null>;
     /**
      * Get a leaderboard in a specific position. Must be between 1 and 10000.
      * @param {number} position The position of the leaderboard.
@@ -153,6 +154,63 @@ declare class TMMapMedalTimes {
      * @type {number}
      */
     bronze: number;
+}
+/**
+ * Represents the map leaderboard.
+ */
+declare class TMMapLeaderboard {
+    constructor(map: any, data: any);
+    /**
+     * The map Instance
+     * @type {TMMap}
+     */
+    map: TMMap;
+    /**
+     * The Client instance
+     * @type {Client}
+     */
+    client: Client;
+    /**
+     * The data
+     * @type {Object}
+     * @private
+     */
+    private _data;
+    /**
+     * The player that got this leaderboard
+     * @returns {Promise<Player>}
+     */
+    player(): Promise<Player>;
+    /**
+     * The player name on this leaderboard
+     * @type {string}
+     */
+    get playerName(): string;
+    /**
+     * The player club tag on this leaderboard
+     * @type {string}
+     */
+    get playerClubTag(): string;
+    /**
+     * The position of the player on this leaderboard
+     * @type {number}
+     */
+    get position(): number;
+    /**
+     * The time in milliseconds of the player
+     * @type {number}
+     */
+    get time(): number;
+    /**
+     * The date when the player get this leaderboard
+     * @type {Date}
+     */
+    get date(): Date;
+    /**
+     * The ghost URL
+     * @type {string}
+     */
+    get ghost(): string;
 }
 import Player = require("./Player");
 /**
@@ -226,61 +284,4 @@ declare class TMExchangeMap {
      * @type {string}
      */
     get download(): string;
-}
-/**
- * Represents the map leaderboard.
- */
-declare class TMMapLeaderboard {
-    constructor(map: any, data: any);
-    /**
-     * The map Instance
-     * @type {TMMap}
-     */
-    map: TMMap;
-    /**
-     * The Client instance
-     * @type {Client}
-     */
-    client: Client;
-    /**
-     * The data
-     * @type {Object}
-     * @private
-     */
-    private _data;
-    /**
-     * The player that got this leaderboard
-     * @returns {Promise<Player>}
-     */
-    player(): Promise<Player>;
-    /**
-     * The player name on this leaderboard
-     * @type {string}
-     */
-    get playerName(): string;
-    /**
-     * The player club tag on this leaderboard
-     * @type {string}
-     */
-    get playerClubTag(): string;
-    /**
-     * The position of the player on this leaderboard
-     * @type {number}
-     */
-    get position(): number;
-    /**
-     * The time in milliseconds of the player
-     * @type {number}
-     */
-    get time(): number;
-    /**
-     * The date when the player get this leaderboard
-     * @type {Date}
-     */
-    get date(): Date;
-    /**
-     * The ghost URL
-     * @type {string}
-     */
-    get ghost(): string;
 }


### PR DESCRIPTION
This fixes #86 by adding possibility to not fetch leaderboard when fetching map info and to fetch leaderboard using the `leaderboardLoadMore()` method