### PR TITLE
Add COTD Leaderboards

### DIFF
--- a/src/managers/COTDManager.js
+++ b/src/managers/COTDManager.js
@@ -2,6 +2,7 @@ const ReqUtil = require('../util/ReqUtil');
 const CacheManager = require('./CacheManager');
 const COTD = require('../structures/COTD');
 const Client = require('../client/Client'); // eslint-disable-line no-unused-vars
+const Player = require('../structures/Player'); // eslint-disable-line no-unused-vars
 
 
 /**
@@ -17,7 +18,7 @@ class COTDManager{
 
         /**
          * The cache manager
-         * @type {CacheManager} 
+         * @type {CacheManager}
          * @private
          */
         this._cache = new CacheManager(this.client, this, COTD);
@@ -28,7 +29,7 @@ class COTDManager{
      * @param {number} [page=0] The page, each page contains 12 items
      * @param {boolean} [cache=this.client.options.cache.enabled] Whether to get the list from cache or not
      * @returns {Promise<Array<COTD>>} The COTD list
-     * @example 
+     * @example
      * client.cotd.get().then(event => {
      *     console.log(event.name);
      * });
@@ -40,7 +41,7 @@ class COTDManager{
             return await this._fetch(page, cache);
         }
     }
-        
+
     /**
      * Fetches a COTD and returns its data
      * @param {number} [page=0] The page
@@ -59,6 +60,111 @@ class COTDManager{
         });
         if (cache) this._cache.set(page, arr);
         return arr;
+    }
+}
+
+class COTDLeaderboard {
+    constructor(client, data) {
+        /**
+         * The client instance.
+         * @type {Client}
+         */
+        this.client = client;
+
+        /**
+         * The data of the COTD leaderboard.
+         * @type {Object}
+         * @private
+         */
+        this._data = data;
+    }
+
+    /**
+     * The player's name
+     * @type {string}
+     */
+    get playerName() {
+        return this._data.player.name;
+    }
+
+    /**
+     * The player's club tag
+     * @type {string}
+     */
+    get playerTag() {
+        return this._data.player.tag;
+    }
+
+    /**
+     * The player's account ID
+     * @type {string}
+     */
+    get playerId() {
+        return this._data.player.id;
+    }
+
+    /**
+     * The player
+     * @returns {Promise<Player>}
+     */
+    async player() {
+        return await this.client.players.get(this.playerId);
+    }
+
+    /**
+     * The position of the player in the selected category
+     * @type {number}
+     */
+    get position() {
+        return this._data.position;
+    }
+
+    /**
+     * The amount of COTD the player has played
+     * @type {number}
+     */
+    get played() {
+        return this._data.totalplayed;
+    }
+
+    /**
+     * The amount of COTD reruns the player has played
+     * @type {number}
+     */
+    get rerunsPlayed() {
+        return this._data.totalplayedreruns;
+    }
+
+    /**
+     * The amount of COTD the player has won
+     * @type {number}
+     */
+    get wins() {
+        return this._data.totalwins;
+    }
+
+    /**
+     * The amount of COTD reruns the player has won
+     * @type {number}
+     */
+    get rerunsWins() {
+        return this._data.winsreruns;
+    }
+
+    /**
+     * The amount of win streak the player has
+     * @type {number}
+     */
+    get winStreak() {
+        return this._data.winstreak;
+    }
+
+    /**
+     * The amount of win streak the player has (reruns included)
+     * @type {number}
+     */
+    get winStreakWithReruns() {
+        return this._data.winstreakreruns;
     }
 }
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -91,6 +91,19 @@ exports.TeamNames = createEnum([
 ]);
 
 /**
+ * All available COTD leaderboard sorting groups.
+ * * `wins`
+ * * `winstreak`
+ * * `totalplayed`
+ * @typedef {string} COTDLeaderboardSortGroup
+ */
+exports.COTDLeaderboardSortGroups = createEnum([
+    'wins',
+    'winstreak',
+    'totalplayed'
+]);
+
+/**
  * @typedef {Object} Constants Constants that can be used in an enum or object-like way.
  * @property {PlayerGroup} GroupTypes All available player groups.
  * @property {MatchmakingGroup} MMTypes All available matchmaking groups.
@@ -99,4 +112,5 @@ exports.TeamNames = createEnum([
  * @property {AdType} AdTypes All available Maniapub Types.
  * @property {MatchStatus} MatchStatus All available Match Status types.
  * @property {TeamName} TeamNames All available Team names for the 3v3 match.
+ * @property {COTDLeaderboardSortGroup} COTDLeaderboardSortGroups All available COTD leaderboard sorting groups.
  */

--- a/typings/managers/COTDManager.d.ts
+++ b/typings/managers/COTDManager.d.ts
@@ -16,6 +16,15 @@ declare class COTDManager {
      */
     private _cache;
     /**
+     * Get the COTD leaderboard by category
+     * @param {COTDLeaderboardSortGroup} [sort="wins"] The leaderboard sorting
+     * @param {boolean} [includeReruns=false] Whether to include reruns when sorting or not
+     * @param {number} [page=0] The page number
+     * @param {boolean} [cache=this.client.options.cache.enabled] Whether to get the list from cache or not
+     * @returns {Promise<Array<COTDLeaderboard>>}
+     */
+    leaderboard(sort?: COTDLeaderboardSortGroup, includeReruns?: boolean, page?: number, cache?: boolean): Promise<Array<COTDLeaderboard>>;
+    /**
      * Fetches the latest COTDs and returns its data
      * @param {number} [page=0] The page, each page contains 12 items
      * @param {boolean} [cache=this.client.options.cache.enabled] Whether to get the list from cache or not
@@ -36,4 +45,78 @@ declare class COTDManager {
     private _fetch;
 }
 import Client = require("../client/Client");
+import { COTDLeaderboardSortGroup } from "../util/Constants";
+/**
+ * Represents a position in the COTD Leaderboard
+ */
+declare class COTDLeaderboard {
+    constructor(client: any, data: any);
+    /**
+     * The client instance.
+     * @type {Client}
+     */
+    client: Client;
+    /**
+     * The data of the COTD leaderboard.
+     * @type {Object}
+     * @private
+     */
+    private _data;
+    /**
+     * The player's name
+     * @type {string}
+     */
+    get playerName(): string;
+    /**
+     * The player's club tag
+     * @type {string}
+     */
+    get playerTag(): string;
+    /**
+     * The player's account ID
+     * @type {string}
+     */
+    get playerId(): string;
+    /**
+     * The player
+     * @returns {Promise<Player>}
+     */
+    player(): Promise<Player>;
+    /**
+     * The position of the player in the selected category
+     * @type {number}
+     */
+    get position(): number;
+    /**
+     * The amount of COTD the player has played
+     * @type {number}
+     */
+    get played(): number;
+    /**
+     * The amount of COTD reruns the player has played
+     * @type {number}
+     */
+    get rerunsPlayed(): number;
+    /**
+     * The amount of COTD the player has won
+     * @type {number}
+     */
+    get wins(): number;
+    /**
+     * The amount of COTD reruns the player has won
+     * @type {number}
+     */
+    get rerunsWins(): number;
+    /**
+     * The amount of win streak the player has
+     * @type {number}
+     */
+    get winStreak(): number;
+    /**
+     * The amount of win streak the player has (reruns included)
+     * @type {number}
+     */
+    get winStreakWithReruns(): number;
+}
 import COTD = require("../structures/COTD");
+import Player = require("../structures/Player");

--- a/typings/util/Constants.d.ts
+++ b/typings/util/Constants.d.ts
@@ -13,6 +13,7 @@ export var AdTypes: any;
 export type MatchStatus = string;
 export var MatchStatus: any;
 export var TeamNames: any;
+export var COTDLeaderboardSortGroups: any;
 /**
  * All available player groups.
  * * `nadeo` - All players from the Nadeo company
@@ -54,6 +55,13 @@ export type AdType = string;
  */
 export type TeamName = string;
 /**
+ * All available COTD leaderboard sorting groups.
+ * * `wins`
+ * * `winstreak`
+ * * `totalplayed`
+ */
+export type COTDLeaderboardSortGroup = string;
+/**
  * Constants that can be used in an enum or object-like way.
  */
 export type Constants = {
@@ -85,4 +93,8 @@ export type Constants = {
      * All available Team names for the 3v3 match.
      */
     TeamNames: TeamName;
+    /**
+     * All available COTD leaderboard sorting groups.
+     */
+    COTDLeaderboardSortGroups: COTDLeaderboardSortGroup;
 };


### PR DESCRIPTION
This closes #89. Added `client.cotd.leaderboard()` method to get the COTD leaderboard by sort and by page